### PR TITLE
Add language selection (DE/EN) and auto-fill ticket ID from active tab URL

### DIFF
--- a/chrome/i18n.js
+++ b/chrome/i18n.js
@@ -1,0 +1,192 @@
+// Lightweight i18n for the Zammad Time Tracker extension.
+//
+// The language is user-selectable in Settings and stored as `language`
+// ('en' or 'de') in chrome.storage.local. Both popup.html and settings.html
+// load this file before their own script, then call setLang()/applyStaticI18n().
+//
+// Dictionary values are either plain strings or functions (for interpolation).
+// Static markup is translated via data-i18n* attributes:
+//   data-i18n             -> textContent
+//   data-i18n-html        -> innerHTML  (only trusted, built-in markup)
+//   data-i18n-placeholder -> placeholder
+//   data-i18n-title       -> title
+
+const I18N = {
+  en: {
+    // --- Settings (static) ---
+    settingsTitle:       'Zammad Settings',
+    baseUrl:             'Base URL',
+    baseUrlHint:         '(no trailing slash)',
+    apiToken:            'API Token',
+    noteSignature:       'Note Signature',
+    noteSignatureHint:   '(appended to every note)',
+    includeTime:         'Include submitted time in note body',
+    languageLabel:       'Language',
+    darkMode:            'Dark mode',
+    activityTypeEnable:  'Enable Activity Type on submission',
+    fetchTypes:          'Fetch Types',
+    activityTypeHint:    'Types must be enabled and established. Find them at:<br>' +
+                         '<strong>Admin &rarr; Time Accounting &rarr; Activity Types</strong>.',
+    save:                'Save',
+    urlPlaceholder:      'https://support.example.com',
+    tokenPlaceholder:    'Your Zammad API token',
+    signaturePlaceholder:'e.g. Logged via Zammad Browser Extension',
+
+    // --- Settings (dynamic) ---
+    saved:               'Saved.',
+    saveUrlTokenFirst:   'Save your URL and Token first.',
+    fetching:            'Fetching...',
+    urlMustStart:        'URL must start with http:// or https://',
+    tokenRequired:       'API token is required.',
+    selectTypeOrDisable: 'Select an activity type or disable the feature.',
+    noTypesFound:        'No active activity types found. Create them at Admin → Time Accounting → Activity Types.',
+    loadedTypes:         n => `Loaded ${n} type${n === 1 ? '' : 's'}.`,
+    fetchFailed:         msg => `Failed: ${msg}`,
+    selectAType:         '-- select a type --',
+    clickFetch:          '-- click Fetch --',
+
+    // --- Popup (static) ---
+    ticketPlaceholder:   'Ticket ID',
+    loadId:              'Load ID',
+    loadIdTitle:         'Load Internal Ticket ID (much shorter than Ticket#)',
+    ticketNum:           'Ticket#',
+    ticketNumTitle:      'Use Ticket# (customer ticket number? use this button!)',
+    existingEntries:     'Existing entries',
+    start:               'Start',
+    pause:               'Pause',
+    reset:               'Reset',
+    notePlaceholder:     'Note (optional)',
+    submitTime:          'Submit Time',
+    timeInputTitle:      'Edit time manually, e.g. 01:30:00',
+
+    // --- Popup (dynamic) ---
+    loading:             'Loading...',
+    totalAccounted:      n => `Total accounted: ${n} min`,
+    minutesTitle:        'Minutes - edit and press Save',
+    invalidTime:         'Invalid time value.',
+    entryUpdated:        'Entry updated.',
+    deleteEntryTitle:    n => `Delete ${n} min entry`,
+    deleteThisEntry:     'Delete this entry?',
+    yes:                 'Yes',
+    no:                  'No',
+    entryDeleted:        'Entry deleted.',
+    resolvingNum:        'Resolving ticket number...',
+    resolved:            (raw, id) => `Resolved #${raw} → ID ${id}`,
+    nothingToSubmit:     'Nothing to submit - timer is at zero.',
+    submitting:          'Submitting...',
+    submitted:           n => `Submitted ${n} min.`,
+    notConfigured:       'Zammad not configured. Open Settings.',
+    couldNotParse:       raw => `Could not parse a ticket number from "${raw}".`,
+    noTicketFound:       n => `No ticket found with number ${n}.`,
+
+    // --- Submitted note body (written into the Zammad ticket) ---
+    noteTimeSubmitted:   n => `time submitted: ${n} min`,
+    noteActivityType:    name => `activity type: ${name}`,
+    noteDefault:         'Time logged via extension'
+  },
+
+  de: {
+    // --- Einstellungen (statisch) ---
+    settingsTitle:       'Zammad Einstellungen',
+    baseUrl:             'Basis-URL',
+    baseUrlHint:         '(ohne abschließenden Schrägstrich)',
+    apiToken:            'API-Token',
+    noteSignature:       'Notiz-Signatur',
+    noteSignatureHint:   '(wird an jede Notiz angehängt)',
+    includeTime:         'Erfasste Zeit in den Notiztext aufnehmen',
+    languageLabel:       'Sprache',
+    darkMode:            'Dunkelmodus',
+    activityTypeEnable:  'Aktivitätstyp beim Senden aktivieren',
+    fetchTypes:          'Typen abrufen',
+    activityTypeHint:    'Typen müssen aktiviert und eingerichtet sein. Zu finden unter:<br>' +
+                         '<strong>Admin &rarr; Zeiterfassung &rarr; Aktivitätstypen</strong>.',
+    save:                'Speichern',
+    urlPlaceholder:      'https://support.example.com',
+    tokenPlaceholder:    'Ihr Zammad API-Token',
+    signaturePlaceholder:'z. B. Erfasst via Zammad Browser-Erweiterung',
+
+    // --- Einstellungen (dynamisch) ---
+    saved:               'Gespeichert.',
+    saveUrlTokenFirst:   'Bitte zuerst URL und Token speichern.',
+    fetching:            'Wird abgerufen...',
+    urlMustStart:        'Die URL muss mit http:// oder https:// beginnen.',
+    tokenRequired:       'API-Token ist erforderlich.',
+    selectTypeOrDisable: 'Bitte einen Aktivitätstyp wählen oder die Funktion deaktivieren.',
+    noTypesFound:        'Keine aktiven Aktivitätstypen gefunden. Erstellen Sie diese unter Admin → Zeiterfassung → Aktivitätstypen.',
+    loadedTypes:         n => `${n} Typ${n === 1 ? '' : 'en'} geladen.`,
+    fetchFailed:         msg => `Fehlgeschlagen: ${msg}`,
+    selectAType:         '-- Typ auswählen --',
+    clickFetch:          '-- Abrufen klicken --',
+
+    // --- Popup (statisch) ---
+    ticketPlaceholder:   'Ticket-ID',
+    loadId:              'ID laden',
+    loadIdTitle:         'Interne Ticket-ID laden (deutlich kürzer als Ticket#)',
+    ticketNum:           'Ticket#',
+    ticketNumTitle:      'Ticket# verwenden (Kunden-Ticketnummer? diesen Knopf nutzen!)',
+    existingEntries:     'Vorhandene Einträge',
+    start:               'Start',
+    pause:               'Pause',
+    reset:               'Zurücksetzen',
+    notePlaceholder:     'Notiz (optional)',
+    submitTime:          'Zeit senden',
+    timeInputTitle:      'Zeit manuell bearbeiten, z. B. 01:30:00',
+
+    // --- Popup (dynamisch) ---
+    loading:             'Wird geladen...',
+    totalAccounted:      n => `Gesamt erfasst: ${n} min`,
+    minutesTitle:        'Minuten – bearbeiten und Speichern drücken',
+    invalidTime:         'Ungültiger Zeitwert.',
+    entryUpdated:        'Eintrag aktualisiert.',
+    deleteEntryTitle:    n => `Eintrag mit ${n} min löschen`,
+    deleteThisEntry:     'Diesen Eintrag löschen?',
+    yes:                 'Ja',
+    no:                  'Nein',
+    entryDeleted:        'Eintrag gelöscht.',
+    resolvingNum:        'Ticketnummer wird aufgelöst...',
+    resolved:            (raw, id) => `#${raw} → ID ${id} aufgelöst`,
+    nothingToSubmit:     'Nichts zu senden – Timer steht auf null.',
+    submitting:          'Wird gesendet...',
+    submitted:           n => `${n} min gesendet.`,
+    notConfigured:       'Zammad ist nicht konfiguriert. Einstellungen öffnen.',
+    couldNotParse:       raw => `Aus "${raw}" konnte keine Ticketnummer ermittelt werden.`,
+    noTicketFound:       n => `Kein Ticket mit der Nummer ${n} gefunden.`,
+
+    // --- Gesendeter Notiztext (wird ins Zammad-Ticket geschrieben) ---
+    noteTimeSubmitted:   n => `Erfasste Zeit: ${n} min`,
+    noteActivityType:    name => `Aktivitätstyp: ${name}`,
+    noteDefault:         'Zeit über Erweiterung erfasst'
+  }
+};
+
+let LANG = 'en';
+
+function setLang(lang) {
+  LANG = I18N[lang] ? lang : 'en';
+}
+
+// Looks up a key for the current language, falling back to English then the
+// key itself. Function values are called with the supplied args.
+function t(key, ...args) {
+  const dict = I18N[LANG] || I18N.en;
+  let val = dict[key];
+  if (val === undefined) val = I18N.en[key];
+  if (val === undefined) return key;
+  return typeof val === 'function' ? val(...args) : val;
+}
+
+// Applies translations to every element carrying a data-i18n* attribute.
+function applyStaticI18n(root = document) {
+  root.querySelectorAll('[data-i18n]').forEach(el => {
+    el.textContent = t(el.dataset.i18n);
+  });
+  root.querySelectorAll('[data-i18n-html]').forEach(el => {
+    el.innerHTML = t(el.dataset.i18nHtml);
+  });
+  root.querySelectorAll('[data-i18n-placeholder]').forEach(el => {
+    el.placeholder = t(el.dataset.i18nPlaceholder);
+  });
+  root.querySelectorAll('[data-i18n-title]').forEach(el => {
+    el.title = t(el.dataset.i18nTitle);
+  });
+}

--- a/chrome/popup.html
+++ b/chrome/popup.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="utf-8">
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
 
@@ -146,9 +147,9 @@
 <body>
 
   <div class="row">
-    <input id="ticketInput" type="text" placeholder="Ticket ID">
-    <button id="loadIdBtn" title="Load Internal Ticket ID (much shorter than Ticket#)">Load ID</button>
-    <button id="loadNumBtn" title="Use Ticket# (customer ticket number? use this button!)">Ticket#</button>
+    <input id="ticketInput" type="text" data-i18n-placeholder="ticketPlaceholder" placeholder="Ticket ID">
+    <button id="loadIdBtn" data-i18n="loadId" data-i18n-title="loadIdTitle" title="Load Internal Ticket ID (much shorter than Ticket#)">Load ID</button>
+    <button id="loadNumBtn" data-i18n="ticketNum" data-i18n-title="ticketNumTitle" title="Use Ticket# (customer ticket number? use this button!)">Ticket#</button>
   </div>
 
   <div id="ticketInfo">
@@ -158,24 +159,25 @@
 
   <!-- Existing time entries, shown after Load -->
   <div id="entriesSection">
-    <div class="label">Existing entries</div>
+    <div class="label" data-i18n="existingEntries">Existing entries</div>
     <div id="entriesList"></div>
   </div>
 
   <input id="timeInput" type="text" value="00:00:00"
-         spellcheck="false" title="Edit time manually, e.g. 01:30:00">
+         spellcheck="false" data-i18n-title="timeInputTitle" title="Edit time manually, e.g. 01:30:00">
 
   <div class="row">
-    <button id="toggleBtn" disabled>Start</button>
-    <button id="resetBtn"  disabled>Reset</button>
+    <button id="toggleBtn" data-i18n="start" disabled>Start</button>
+    <button id="resetBtn" data-i18n="reset" disabled>Reset</button>
   </div>
 
-  <textarea id="note" placeholder="Note (optional)"></textarea>
+  <textarea id="note" data-i18n-placeholder="notePlaceholder" placeholder="Note (optional)"></textarea>
 
-  <button id="submitBtn" disabled>Submit Time</button>
+  <button id="submitBtn" data-i18n="submitTime" disabled>Submit Time</button>
 
   <div id="status"></div>
 
+  <script src="i18n.js"></script>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/chrome/popup.js
+++ b/chrome/popup.js
@@ -8,6 +8,7 @@
 //   includeTime              - bool: append "time submitted: X min" to note
 //   activityTypeEnabled      - bool: send activity type on submit
 //   activityTypeName         - activity type name as it appears in Zammad
+//   language                 - UI language ('en' or 'de'), set in Settings
 //
 // The timer is timestamp-based, not counter-based.
 //
@@ -23,7 +24,7 @@ async function zammadFetch(path, options = {}) {
   const { zammadUrl, zammadToken } = await store.get(['zammadUrl', 'zammadToken']);
 
   if (!zammadUrl || !zammadToken) {
-    throw new Error('Zammad not configured. Open Settings.');
+    throw new Error(t('notConfigured'));
   }
 
   const res = await fetch(`${zammadUrl}${path}`, {
@@ -48,7 +49,7 @@ async function zammadFetch(path, options = {}) {
 // Zammad links both records atomically, which is why we use this over the bare time_accountings endpoint.
 async function postTimeAccounting(ticketId, minutes, note, typeName = null) {
   const article = {
-    body: note || 'Time logged via extension',
+    body: note || t('noteDefault'),
     internal: true,
     time_unit: parseFloat(minutes.toFixed(4))
   };
@@ -79,7 +80,7 @@ async function resolveTicketNumber(raw) {
   // Extracts only the trailing digit sequence.
   const normalized = raw.trim().replace(/^.*?(\d+)\s*$/, '$1');
   if (!normalized) {
-    throw new Error(`Could not parse a ticket number from "${raw}".`);
+    throw new Error(t('couldNotParse', raw));
   }
 
   // POST with an explicit ticket.number condition is the reliable exact-match
@@ -97,7 +98,33 @@ async function resolveTicketNumber(raw) {
 
   if (data.record_ids?.length) return String(data.record_ids[0]);
 
-  throw new Error(`No ticket found with number ${normalized}.`);
+  throw new Error(t('noTicketFound', normalized));
+}
+
+// ---------------------------------------------------------------------------
+// Active-tab ticket detection
+// ---------------------------------------------------------------------------
+
+// Extracts the internal ticket ID from a Zammad ticket-zoom URL, but only when
+// the URL sits under the configured Base URL. Zammad routes look like
+// `https://host/#ticket/zoom/12345`.
+function ticketIdFromUrl(tabUrl, baseUrl) {
+  if (!tabUrl || !baseUrl) return null;
+  const base = baseUrl.replace(/\/+$/, '');
+  if (!tabUrl.startsWith(base)) return null;
+  const m = tabUrl.match(/#ticket\/zoom\/(\d+)/);
+  return m ? m[1] : null;
+}
+
+// Reads the active tab's URL and returns the ticket ID it points at, or null.
+async function detectTicketFromActiveTab(baseUrl) {
+  if (!baseUrl) return null;
+  try {
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    return ticketIdFromUrl(tab?.url, baseUrl);
+  } catch (_) {
+    return null; // tabs API/permission unavailable — silently skip
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -163,7 +190,7 @@ async function render() {
   const hasTicket = !!s.ticketId;
   const running = !!s.startedAt;
 
-  $('toggleBtn').textContent = running ? 'Pause' : 'Start';
+  $('toggleBtn').textContent = running ? t('pause') : t('start');
   $('toggleBtn').disabled = !hasTicket;
   $('resetBtn').disabled  = !hasTicket;
   $('submitBtn').disabled = !hasTicket;
@@ -186,14 +213,14 @@ function showTicketInfo(title, entries) {
   const total = entries.reduce((sum, e) => sum + parseFloat(e.time_unit || '0'), 0);
   $('ticketInfo').style.display = 'block';
   $('ticketTitle').textContent = title;
-  $('accountedTime').textContent = `Total accounted: ${parseFloat(total.toFixed(2))} min`;
+  $('accountedTime').textContent = t('totalAccounted', parseFloat(total.toFixed(2)));
 }
 
 async function refreshTicketData(ticketId) {
   try {
     const entries = await zammadFetch(`/api/v1/tickets/${ticketId}/time_accountings`);
     const total = entries.reduce((sum, e) => sum + parseFloat(e.time_unit || '0'), 0);
-    $('accountedTime').textContent = `Total accounted: ${parseFloat(total.toFixed(2))} min`;
+    $('accountedTime').textContent = t('totalAccounted', parseFloat(total.toFixed(2)));
     renderEntries(ticketId, await resolveTypeNames(entries));
   } catch (_) { /* non-fatal */ }
 }
@@ -218,18 +245,18 @@ function renderEntries(ticketId, entries) {
     const input = document.createElement('input');
     input.type = 'text';
     input.value = parseFloat(entry.time_unit).toFixed(2);
-    input.title = 'Minutes - edit and press Save';
+    input.title = t('minutesTitle');
 
     const saveBtn = document.createElement('button');
-    saveBtn.textContent = 'Save';
+    saveBtn.textContent = t('save');
     saveBtn.className = 'save';
     saveBtn.onclick = async () => {
       const minutes = parseFloat(input.value);
-      if (isNaN(minutes) || minutes < 0) { setStatus('Invalid time value.', 'error'); return; }
+      if (isNaN(minutes) || minutes < 0) { setStatus(t('invalidTime'), 'error'); return; }
       saveBtn.disabled = true;
       try {
         await patchTimeAccounting(ticketId, entry.id, minutes);
-        setStatus('Entry updated.', 'ok');
+        setStatus(t('entryUpdated'), 'ok');
         refreshTicketData(ticketId);
       } catch (e) {
         setStatus(e.message, 'error');
@@ -240,7 +267,7 @@ function renderEntries(ticketId, entries) {
     const delBtn = document.createElement('button');
     delBtn.textContent = '-';
     delBtn.className = 'del';
-    delBtn.title = `Delete ${parseFloat(entry.time_unit).toFixed(2)} min entry`;
+    delBtn.title = t('deleteEntryTitle', parseFloat(entry.time_unit).toFixed(2));
     delBtn.onclick = () => {
       // Replace the row with an inline yes/no prompt.
       // Chrome's native confirm() freezes the extension popup and puts the
@@ -249,17 +276,17 @@ function renderEntries(ticketId, entries) {
 
       const msg = document.createElement('span');
       msg.className = 'entry-date';
-      msg.textContent = 'Delete this entry?';
+      msg.textContent = t('deleteThisEntry');
 
       const yesBtn = document.createElement('button');
-      yesBtn.textContent = 'Yes';
+      yesBtn.textContent = t('yes');
       yesBtn.className = 'save';
       yesBtn.onclick = async () => {
         yesBtn.disabled = true;
         noBtn.disabled = true;
         try {
           await deleteTimeAccounting(ticketId, entry.id);
-          setStatus('Entry deleted.', 'ok');
+          setStatus(t('entryDeleted'), 'ok');
         } catch (e) {
           setStatus(e.message, 'error');
         }
@@ -267,7 +294,7 @@ function renderEntries(ticketId, entries) {
       };
 
       const noBtn = document.createElement('button');
-      noBtn.textContent = 'No';
+      noBtn.textContent = t('no');
       noBtn.onclick = () => refreshTicketData(ticketId);
 
       row.append(msg, yesBtn, noBtn);
@@ -294,7 +321,7 @@ async function loadTicketById(id) {
     return;
   }
 
-  setStatus('Loading...');
+  setStatus(t('loading'));
   try {
     const [ticket, entries] = await Promise.all([
       zammadFetch(`/api/v1/tickets/${id}`),
@@ -328,11 +355,11 @@ $('loadNumBtn').onclick = async () => {
   const raw = $('ticketInput').value.trim();
   if (!raw) { await loadTicketById(''); return; }
 
-  setStatus('Resolving ticket number...');
+  setStatus(t('resolvingNum'));
   $('loadNumBtn').disabled = true;
   try {
     const resolvedId = await resolveTicketNumber(raw);
-    setStatus(`Resolved #${raw} → ID ${resolvedId}`);
+    setStatus(t('resolved', raw, resolvedId));
     await loadTicketById(resolvedId);
   } catch (e) {
     setStatus(e.message, 'error');
@@ -379,17 +406,17 @@ $('submitBtn').onclick = async () => {
   await store.set({ accumulatedMs: ms, startedAt: null });
   render();
 
-  if (ms < 1000) { setStatus('Nothing to submit - timer is at zero.', 'error'); return; }
+  if (ms < 1000) { setStatus(t('nothingToSubmit'), 'error'); return; }
 
-  setStatus('Submitting...');
+  setStatus(t('submitting'));
   try {
     const minutes = ms / 60000;
     // Build note: user text, optional "time | type" line, optional signature.
     const timePart = s.includeTime
-      ? `time submitted: ${parseFloat(minutes.toFixed(2))} min`
+      ? t('noteTimeSubmitted', parseFloat(minutes.toFixed(2)))
       : null;
     const typePart = s.activityTypeEnabled && s.activityTypeName
-      ? `activity type: ${s.activityTypeName}`
+      ? t('noteActivityType', s.activityTypeName)
       : null;
     const timeLine = [timePart, typePart].filter(Boolean).join(' | ') || null;
 
@@ -399,7 +426,7 @@ $('submitBtn').onclick = async () => {
       s.signature
     ].filter(Boolean);
 
-    const note = parts.join('\n') || 'Time logged via extension';
+    const note = parts.join('\n') || t('noteDefault');
     const effectiveTypeName = s.activityTypeEnabled && s.activityTypeName
       ? s.activityTypeName
       : null;
@@ -408,7 +435,7 @@ $('submitBtn').onclick = async () => {
     // Reset timer on success
     await store.set({ accumulatedMs: 0, startedAt: null, note: '' });
     $('note').value = '';
-    setStatus(`Submitted ${parseFloat(minutes.toFixed(2))} min.`, 'ok');
+    setStatus(t('submitted', parseFloat(minutes.toFixed(2))), 'ok');
 
     // Refresh the accounted total so user can see it updated
     refreshTicketData(s.ticketId);
@@ -423,9 +450,29 @@ $('submitBtn').onclick = async () => {
 // ---------------------------------------------------------------------------
 
 (async () => {
-  const s = await store.get(['ticketId', 'zammadUrl', 'zammadToken', 'darkMode', 'note']);
+  const s = await store.get([
+    'ticketId', 'zammadUrl', 'zammadToken', 'darkMode', 'note',
+    'startedAt', 'accumulatedMs', 'language'
+  ]);
+
+  setLang(s.language || 'en');
+  applyStaticI18n();
+
   if (s.darkMode) document.body.classList.add('dark');
   if (s.note) $('note').value = s.note;
+
+  // Auto-fill the ticket from the active tab's URL when it sits under the
+  // configured Base URL. We only adopt it when the popup has no unsubmitted
+  // time on another ticket, so a running/banked timer is never discarded.
+  const urlTicketId  = await detectTicketFromActiveTab(s.zammadUrl);
+  const hasUnsubmitted = !!s.startedAt || (s.accumulatedMs || 0) > 0;
+
+  if (urlTicketId && urlTicketId !== s.ticketId && !hasUnsubmitted
+      && s.zammadUrl && s.zammadToken) {
+    // loadTicketById fetches the ticket, resets the timer and re-renders.
+    await loadTicketById(urlTicketId);
+    return;
+  }
 
   if (s.ticketId && s.zammadUrl && s.zammadToken) {
     $('ticketInput').value = s.ticketId;

--- a/chrome/settings.html
+++ b/chrome/settings.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="utf-8">
   <style>
     body {
       font-family: Arial, sans-serif;
@@ -81,53 +82,60 @@
   </style>
 </head>
 <body>
-  <h2>Zammad Settings</h2>
+  <h2 data-i18n="settingsTitle">Zammad Settings</h2>
 
-  <label>Base URL <small>(no trailing slash)</small></label>
-  <input id="url" type="text" placeholder="https://support.example.com">
+  <label><span data-i18n="baseUrl">Base URL</span> <small data-i18n="baseUrlHint">(no trailing slash)</small></label>
+  <input id="url" type="text" data-i18n-placeholder="urlPlaceholder" placeholder="https://support.example.com">
 
-  <label>API Token</label>
-  <input id="token" type="password" placeholder="Your Zammad API token">
+  <label data-i18n="apiToken">API Token</label>
+  <input id="token" type="password" data-i18n-placeholder="tokenPlaceholder" placeholder="Your Zammad API token">
 
-  <label>Note Signature <small>(appended to every note)</small></label>
-  <input id="signature" type="text" placeholder="e.g. Logged via Zammad Browser Extension">
+  <label><span data-i18n="noteSignature">Note Signature</span> <small data-i18n="noteSignatureHint">(appended to every note)</small></label>
+  <input id="signature" type="text" data-i18n-placeholder="signaturePlaceholder" placeholder="e.g. Logged via Zammad Browser Extension">
 
   <label class="checkbox-label">
     <input id="includeTime" type="checkbox">
-    Include submitted time in note body
+    <span data-i18n="includeTime">Include submitted time in note body</span>
   </label>
 
   <hr>
 
+  <label data-i18n="languageLabel">Language</label>
+  <select id="language">
+    <option value="en">English</option>
+    <option value="de">Deutsch</option>
+  </select>
+
   <label class="checkbox-label">
     <input id="darkMode" type="checkbox">
-    Dark mode
+    <span data-i18n="darkMode">Dark mode</span>
   </label>
 
   <hr>
 
   <label class="checkbox-label">
     <input id="activityTypeEnabled" type="checkbox">
-    Enable Activity Type on submission
+    <span data-i18n="activityTypeEnable">Enable Activity Type on submission</span>
   </label>
 
   <div id="activityTypeSection">
     <div class="fetch-row">
       <select id="activityTypeSelect">
-        <option value="">-- click Fetch --</option>
+        <option value="" data-i18n="clickFetch">-- click Fetch --</option>
       </select>
-      <button id="fetchTypesBtn" type="button">Fetch Types</button>
+      <button id="fetchTypesBtn" type="button" data-i18n="fetchTypes">Fetch Types</button>
     </div>
     <div id="fetchStatus"></div>
-    <p class="hint">
+    <p class="hint" data-i18n-html="activityTypeHint">
       Types must be enabled and established. Find them at:<br>
       <strong>Admin &rarr; Time Accounting &rarr; Activity Types</strong>.
     </p>
   </div>
 
-  <button id="saveBtn">Save</button>
+  <button id="saveBtn" data-i18n="save">Save</button>
   <div id="msg"></div>
 
+  <script src="i18n.js"></script>
   <script src="settings.js"></script>
 </body>
 </html>

--- a/chrome/settings.js
+++ b/chrome/settings.js
@@ -13,8 +13,12 @@ function preselectType(name) {
 }
 
 chrome.storage.local.get(
-  ['zammadUrl', 'zammadToken', 'signature', 'includeTime', 'darkMode', 'activityTypeEnabled', 'activityTypeName'],
-  ({ zammadUrl, zammadToken, signature, includeTime, darkMode, activityTypeEnabled, activityTypeName }) => {
+  ['zammadUrl', 'zammadToken', 'signature', 'includeTime', 'darkMode', 'language', 'activityTypeEnabled', 'activityTypeName'],
+  ({ zammadUrl, zammadToken, signature, includeTime, darkMode, language, activityTypeEnabled, activityTypeName }) => {
+    setLang(language || 'en');
+    get('language').value = language || 'en';
+    applyStaticI18n();
+
     if (zammadUrl)  get('url').value       = zammadUrl;
     if (zammadToken) get('token').value    = zammadToken;
     if (signature)  get('signature').value = signature;
@@ -28,6 +32,12 @@ chrome.storage.local.get(
     if (activityTypeName)    preselectType(activityTypeName);
   }
 );
+
+// Re-translate the page live when the language changes (saved on Save).
+get('language').addEventListener('change', () => {
+  setLang(get('language').value);
+  applyStaticI18n();
+});
 
 get('darkMode').addEventListener('change', () => {
   document.body.classList.toggle('dark', get('darkMode').checked);
@@ -49,12 +59,12 @@ get('fetchTypesBtn').onclick = async () => {
 
   if (!url || !token) {
     status.style.color = 'red';
-    status.textContent = 'Save your URL and Token first.';
+    status.textContent = t('saveUrlTokenFirst');
     return;
   }
 
   status.style.color = '#888';
-  status.textContent = 'Fetching...';
+  status.textContent = t('fetching');
 
   const authHeaders = { 'Authorization': `Token token=${token}` };
 
@@ -96,26 +106,26 @@ get('fetchTypesBtn').onclick = async () => {
       types = [...new Set(log.map(e => e.type).filter(Boolean))].sort();
     } catch (e) {
       status.style.color = 'red';
-      status.textContent = `Failed: ${e.message}`;
+      status.textContent = t('fetchFailed', e.message);
       return;
     }
   }
 
   if (!types.length) {
     status.style.color = '#888';
-    status.textContent =
-      'No active activity types found. Create them at Admin → Time Accounting → Activity Types.';
+    status.textContent = t('noTypesFound');
     return;
   }
 
   const select  = get('activityTypeSelect');
   const current = select.value;
-  select.innerHTML = '<option value="">-- select a type --</option>';
+  select.innerHTML = '';
+  select.add(new Option(t('selectAType'), ''));
   types.forEach(name => select.add(new Option(name, name)));
   if (current) select.value = current;
 
   status.style.color = 'green';
-  status.textContent = `Loaded ${types.length} type${types.length === 1 ? '' : 's'}.`;
+  status.textContent = t('loadedTypes', types.length);
 };
 
 get('saveBtn').onclick = () => {
@@ -124,31 +134,32 @@ get('saveBtn').onclick = () => {
   const signature           = get('signature').value.trim();
   const includeTime         = get('includeTime').checked;
   const darkMode            = get('darkMode').checked;
+  const language            = get('language').value;
   const activityTypeEnabled = get('activityTypeEnabled').checked;
   const activityTypeName    = get('activityTypeSelect').value;
   const msg                 = get('msg');
 
   if (!url.startsWith('https://') && !url.startsWith('http://')) {
     msg.style.color = 'red';
-    msg.textContent = 'URL must start with http:// or https://';
+    msg.textContent = t('urlMustStart');
     return;
   }
   if (!token) {
     msg.style.color = 'red';
-    msg.textContent = 'API token is required.';
+    msg.textContent = t('tokenRequired');
     return;
   }
   if (activityTypeEnabled && !activityTypeName) {
     msg.style.color = 'red';
-    msg.textContent = 'Select an activity type or disable the feature.';
+    msg.textContent = t('selectTypeOrDisable');
     return;
   }
 
   chrome.storage.local.set(
-    { zammadUrl: url, zammadToken: token, signature, includeTime, darkMode, activityTypeEnabled, activityTypeName },
+    { zammadUrl: url, zammadToken: token, signature, includeTime, darkMode, language, activityTypeEnabled, activityTypeName },
     () => {
       msg.style.color = 'green';
-      msg.textContent = 'Saved.';
+      msg.textContent = t('saved');
     }
   );
 };

--- a/firefox/i18n.js
+++ b/firefox/i18n.js
@@ -1,0 +1,192 @@
+// Lightweight i18n for the Zammad Time Tracker extension.
+//
+// The language is user-selectable in Settings and stored as `language`
+// ('en' or 'de') in chrome.storage.local. Both popup.html and settings.html
+// load this file before their own script, then call setLang()/applyStaticI18n().
+//
+// Dictionary values are either plain strings or functions (for interpolation).
+// Static markup is translated via data-i18n* attributes:
+//   data-i18n             -> textContent
+//   data-i18n-html        -> innerHTML  (only trusted, built-in markup)
+//   data-i18n-placeholder -> placeholder
+//   data-i18n-title       -> title
+
+const I18N = {
+  en: {
+    // --- Settings (static) ---
+    settingsTitle:       'Zammad Settings',
+    baseUrl:             'Base URL',
+    baseUrlHint:         '(no trailing slash)',
+    apiToken:            'API Token',
+    noteSignature:       'Note Signature',
+    noteSignatureHint:   '(appended to every note)',
+    includeTime:         'Include submitted time in note body',
+    languageLabel:       'Language',
+    darkMode:            'Dark mode',
+    activityTypeEnable:  'Enable Activity Type on submission',
+    fetchTypes:          'Fetch Types',
+    activityTypeHint:    'Types must be enabled and established. Find them at:<br>' +
+                         '<strong>Admin &rarr; Time Accounting &rarr; Activity Types</strong>.',
+    save:                'Save',
+    urlPlaceholder:      'https://support.example.com',
+    tokenPlaceholder:    'Your Zammad API token',
+    signaturePlaceholder:'e.g. Logged via Zammad Browser Extension',
+
+    // --- Settings (dynamic) ---
+    saved:               'Saved.',
+    saveUrlTokenFirst:   'Save your URL and Token first.',
+    fetching:            'Fetching...',
+    urlMustStart:        'URL must start with http:// or https://',
+    tokenRequired:       'API token is required.',
+    selectTypeOrDisable: 'Select an activity type or disable the feature.',
+    noTypesFound:        'No active activity types found. Create them at Admin → Time Accounting → Activity Types.',
+    loadedTypes:         n => `Loaded ${n} type${n === 1 ? '' : 's'}.`,
+    fetchFailed:         msg => `Failed: ${msg}`,
+    selectAType:         '-- select a type --',
+    clickFetch:          '-- click Fetch --',
+
+    // --- Popup (static) ---
+    ticketPlaceholder:   'Ticket ID',
+    loadId:              'Load ID',
+    loadIdTitle:         'Load Internal Ticket ID (much shorter than Ticket#)',
+    ticketNum:           'Ticket#',
+    ticketNumTitle:      'Use Ticket# (customer ticket number? use this button!)',
+    existingEntries:     'Existing entries',
+    start:               'Start',
+    pause:               'Pause',
+    reset:               'Reset',
+    notePlaceholder:     'Note (optional)',
+    submitTime:          'Submit Time',
+    timeInputTitle:      'Edit time manually, e.g. 01:30:00',
+
+    // --- Popup (dynamic) ---
+    loading:             'Loading...',
+    totalAccounted:      n => `Total accounted: ${n} min`,
+    minutesTitle:        'Minutes - edit and press Save',
+    invalidTime:         'Invalid time value.',
+    entryUpdated:        'Entry updated.',
+    deleteEntryTitle:    n => `Delete ${n} min entry`,
+    deleteThisEntry:     'Delete this entry?',
+    yes:                 'Yes',
+    no:                  'No',
+    entryDeleted:        'Entry deleted.',
+    resolvingNum:        'Resolving ticket number...',
+    resolved:            (raw, id) => `Resolved #${raw} → ID ${id}`,
+    nothingToSubmit:     'Nothing to submit - timer is at zero.',
+    submitting:          'Submitting...',
+    submitted:           n => `Submitted ${n} min.`,
+    notConfigured:       'Zammad not configured. Open Settings.',
+    couldNotParse:       raw => `Could not parse a ticket number from "${raw}".`,
+    noTicketFound:       n => `No ticket found with number ${n}.`,
+
+    // --- Submitted note body (written into the Zammad ticket) ---
+    noteTimeSubmitted:   n => `time submitted: ${n} min`,
+    noteActivityType:    name => `activity type: ${name}`,
+    noteDefault:         'Time logged via extension'
+  },
+
+  de: {
+    // --- Einstellungen (statisch) ---
+    settingsTitle:       'Zammad Einstellungen',
+    baseUrl:             'Basis-URL',
+    baseUrlHint:         '(ohne abschließenden Schrägstrich)',
+    apiToken:            'API-Token',
+    noteSignature:       'Notiz-Signatur',
+    noteSignatureHint:   '(wird an jede Notiz angehängt)',
+    includeTime:         'Erfasste Zeit in den Notiztext aufnehmen',
+    languageLabel:       'Sprache',
+    darkMode:            'Dunkelmodus',
+    activityTypeEnable:  'Aktivitätstyp beim Senden aktivieren',
+    fetchTypes:          'Typen abrufen',
+    activityTypeHint:    'Typen müssen aktiviert und eingerichtet sein. Zu finden unter:<br>' +
+                         '<strong>Admin &rarr; Zeiterfassung &rarr; Aktivitätstypen</strong>.',
+    save:                'Speichern',
+    urlPlaceholder:      'https://support.example.com',
+    tokenPlaceholder:    'Ihr Zammad API-Token',
+    signaturePlaceholder:'z. B. Erfasst via Zammad Browser-Erweiterung',
+
+    // --- Einstellungen (dynamisch) ---
+    saved:               'Gespeichert.',
+    saveUrlTokenFirst:   'Bitte zuerst URL und Token speichern.',
+    fetching:            'Wird abgerufen...',
+    urlMustStart:        'Die URL muss mit http:// oder https:// beginnen.',
+    tokenRequired:       'API-Token ist erforderlich.',
+    selectTypeOrDisable: 'Bitte einen Aktivitätstyp wählen oder die Funktion deaktivieren.',
+    noTypesFound:        'Keine aktiven Aktivitätstypen gefunden. Erstellen Sie diese unter Admin → Zeiterfassung → Aktivitätstypen.',
+    loadedTypes:         n => `${n} Typ${n === 1 ? '' : 'en'} geladen.`,
+    fetchFailed:         msg => `Fehlgeschlagen: ${msg}`,
+    selectAType:         '-- Typ auswählen --',
+    clickFetch:          '-- Abrufen klicken --',
+
+    // --- Popup (statisch) ---
+    ticketPlaceholder:   'Ticket-ID',
+    loadId:              'ID laden',
+    loadIdTitle:         'Interne Ticket-ID laden (deutlich kürzer als Ticket#)',
+    ticketNum:           'Ticket#',
+    ticketNumTitle:      'Ticket# verwenden (Kunden-Ticketnummer? diesen Knopf nutzen!)',
+    existingEntries:     'Vorhandene Einträge',
+    start:               'Start',
+    pause:               'Pause',
+    reset:               'Zurücksetzen',
+    notePlaceholder:     'Notiz (optional)',
+    submitTime:          'Zeit senden',
+    timeInputTitle:      'Zeit manuell bearbeiten, z. B. 01:30:00',
+
+    // --- Popup (dynamisch) ---
+    loading:             'Wird geladen...',
+    totalAccounted:      n => `Gesamt erfasst: ${n} min`,
+    minutesTitle:        'Minuten – bearbeiten und Speichern drücken',
+    invalidTime:         'Ungültiger Zeitwert.',
+    entryUpdated:        'Eintrag aktualisiert.',
+    deleteEntryTitle:    n => `Eintrag mit ${n} min löschen`,
+    deleteThisEntry:     'Diesen Eintrag löschen?',
+    yes:                 'Ja',
+    no:                  'Nein',
+    entryDeleted:        'Eintrag gelöscht.',
+    resolvingNum:        'Ticketnummer wird aufgelöst...',
+    resolved:            (raw, id) => `#${raw} → ID ${id} aufgelöst`,
+    nothingToSubmit:     'Nichts zu senden – Timer steht auf null.',
+    submitting:          'Wird gesendet...',
+    submitted:           n => `${n} min gesendet.`,
+    notConfigured:       'Zammad ist nicht konfiguriert. Einstellungen öffnen.',
+    couldNotParse:       raw => `Aus "${raw}" konnte keine Ticketnummer ermittelt werden.`,
+    noTicketFound:       n => `Kein Ticket mit der Nummer ${n} gefunden.`,
+
+    // --- Gesendeter Notiztext (wird ins Zammad-Ticket geschrieben) ---
+    noteTimeSubmitted:   n => `Erfasste Zeit: ${n} min`,
+    noteActivityType:    name => `Aktivitätstyp: ${name}`,
+    noteDefault:         'Zeit über Erweiterung erfasst'
+  }
+};
+
+let LANG = 'en';
+
+function setLang(lang) {
+  LANG = I18N[lang] ? lang : 'en';
+}
+
+// Looks up a key for the current language, falling back to English then the
+// key itself. Function values are called with the supplied args.
+function t(key, ...args) {
+  const dict = I18N[LANG] || I18N.en;
+  let val = dict[key];
+  if (val === undefined) val = I18N.en[key];
+  if (val === undefined) return key;
+  return typeof val === 'function' ? val(...args) : val;
+}
+
+// Applies translations to every element carrying a data-i18n* attribute.
+function applyStaticI18n(root = document) {
+  root.querySelectorAll('[data-i18n]').forEach(el => {
+    el.textContent = t(el.dataset.i18n);
+  });
+  root.querySelectorAll('[data-i18n-html]').forEach(el => {
+    el.innerHTML = t(el.dataset.i18nHtml);
+  });
+  root.querySelectorAll('[data-i18n-placeholder]').forEach(el => {
+    el.placeholder = t(el.dataset.i18nPlaceholder);
+  });
+  root.querySelectorAll('[data-i18n-title]').forEach(el => {
+    el.title = t(el.dataset.i18nTitle);
+  });
+}

--- a/firefox/popup.html
+++ b/firefox/popup.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="utf-8">
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
 
@@ -146,9 +147,9 @@
 <body>
 
   <div class="row">
-    <input id="ticketInput" type="text" placeholder="Ticket ID">
-    <button id="loadIdBtn" title="Load Internal Ticket ID (much shorter than Ticket#)">Load ID</button>
-    <button id="loadNumBtn" title="Use Ticket# (customer ticket number? use this button!)">Ticket#</button>
+    <input id="ticketInput" type="text" data-i18n-placeholder="ticketPlaceholder" placeholder="Ticket ID">
+    <button id="loadIdBtn" data-i18n="loadId" data-i18n-title="loadIdTitle" title="Load Internal Ticket ID (much shorter than Ticket#)">Load ID</button>
+    <button id="loadNumBtn" data-i18n="ticketNum" data-i18n-title="ticketNumTitle" title="Use Ticket# (customer ticket number? use this button!)">Ticket#</button>
   </div>
 
   <div id="ticketInfo">
@@ -158,24 +159,25 @@
 
   <!-- Existing time entries, shown after Load -->
   <div id="entriesSection">
-    <div class="label">Existing entries</div>
+    <div class="label" data-i18n="existingEntries">Existing entries</div>
     <div id="entriesList"></div>
   </div>
 
   <input id="timeInput" type="text" value="00:00:00"
-         spellcheck="false" title="Edit time manually, e.g. 01:30:00">
+         spellcheck="false" data-i18n-title="timeInputTitle" title="Edit time manually, e.g. 01:30:00">
 
   <div class="row">
-    <button id="toggleBtn" disabled>Start</button>
-    <button id="resetBtn"  disabled>Reset</button>
+    <button id="toggleBtn" data-i18n="start" disabled>Start</button>
+    <button id="resetBtn" data-i18n="reset" disabled>Reset</button>
   </div>
 
-  <textarea id="note" placeholder="Note (optional)"></textarea>
+  <textarea id="note" data-i18n-placeholder="notePlaceholder" placeholder="Note (optional)"></textarea>
 
-  <button id="submitBtn" disabled>Submit Time</button>
+  <button id="submitBtn" data-i18n="submitTime" disabled>Submit Time</button>
 
   <div id="status"></div>
 
+  <script src="i18n.js"></script>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/firefox/popup.js
+++ b/firefox/popup.js
@@ -8,6 +8,7 @@
 //   includeTime              - bool: append "time submitted: X min" to note
 //   activityTypeEnabled      - bool: send activity type on submit
 //   activityTypeName         - activity type name as it appears in Zammad
+//   language                 - UI language ('en' or 'de'), set in Settings
 //
 // The timer is timestamp-based, not counter-based.
 //
@@ -23,7 +24,7 @@ async function zammadFetch(path, options = {}) {
   const { zammadUrl, zammadToken } = await store.get(['zammadUrl', 'zammadToken']);
 
   if (!zammadUrl || !zammadToken) {
-    throw new Error('Zammad not configured. Open Settings.');
+    throw new Error(t('notConfigured'));
   }
 
   const res = await fetch(`${zammadUrl}${path}`, {
@@ -48,7 +49,7 @@ async function zammadFetch(path, options = {}) {
 // Zammad links both records atomically, which is why we use this over the bare time_accountings endpoint.
 async function postTimeAccounting(ticketId, minutes, note, typeName = null) {
   const article = {
-    body: note || 'Time logged via extension',
+    body: note || t('noteDefault'),
     internal: true,
     time_unit: parseFloat(minutes.toFixed(4))
   };
@@ -79,7 +80,7 @@ async function resolveTicketNumber(raw) {
   // Extracts only the trailing digit sequence.
   const normalized = raw.trim().replace(/^.*?(\d+)\s*$/, '$1');
   if (!normalized) {
-    throw new Error(`Could not parse a ticket number from "${raw}".`);
+    throw new Error(t('couldNotParse', raw));
   }
 
   // POST with an explicit ticket.number condition is the reliable exact-match
@@ -97,7 +98,33 @@ async function resolveTicketNumber(raw) {
 
   if (data.record_ids?.length) return String(data.record_ids[0]);
 
-  throw new Error(`No ticket found with number ${normalized}.`);
+  throw new Error(t('noTicketFound', normalized));
+}
+
+// ---------------------------------------------------------------------------
+// Active-tab ticket detection
+// ---------------------------------------------------------------------------
+
+// Extracts the internal ticket ID from a Zammad ticket-zoom URL, but only when
+// the URL sits under the configured Base URL. Zammad routes look like
+// `https://host/#ticket/zoom/12345`.
+function ticketIdFromUrl(tabUrl, baseUrl) {
+  if (!tabUrl || !baseUrl) return null;
+  const base = baseUrl.replace(/\/+$/, '');
+  if (!tabUrl.startsWith(base)) return null;
+  const m = tabUrl.match(/#ticket\/zoom\/(\d+)/);
+  return m ? m[1] : null;
+}
+
+// Reads the active tab's URL and returns the ticket ID it points at, or null.
+async function detectTicketFromActiveTab(baseUrl) {
+  if (!baseUrl) return null;
+  try {
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    return ticketIdFromUrl(tab?.url, baseUrl);
+  } catch (_) {
+    return null; // tabs API/permission unavailable — silently skip
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -163,7 +190,7 @@ async function render() {
   const hasTicket = !!s.ticketId;
   const running = !!s.startedAt;
 
-  $('toggleBtn').textContent = running ? 'Pause' : 'Start';
+  $('toggleBtn').textContent = running ? t('pause') : t('start');
   $('toggleBtn').disabled = !hasTicket;
   $('resetBtn').disabled  = !hasTicket;
   $('submitBtn').disabled = !hasTicket;
@@ -186,14 +213,14 @@ function showTicketInfo(title, entries) {
   const total = entries.reduce((sum, e) => sum + parseFloat(e.time_unit || '0'), 0);
   $('ticketInfo').style.display = 'block';
   $('ticketTitle').textContent = title;
-  $('accountedTime').textContent = `Total accounted: ${parseFloat(total.toFixed(2))} min`;
+  $('accountedTime').textContent = t('totalAccounted', parseFloat(total.toFixed(2)));
 }
 
 async function refreshTicketData(ticketId) {
   try {
     const entries = await zammadFetch(`/api/v1/tickets/${ticketId}/time_accountings`);
     const total = entries.reduce((sum, e) => sum + parseFloat(e.time_unit || '0'), 0);
-    $('accountedTime').textContent = `Total accounted: ${parseFloat(total.toFixed(2))} min`;
+    $('accountedTime').textContent = t('totalAccounted', parseFloat(total.toFixed(2)));
     renderEntries(ticketId, await resolveTypeNames(entries));
   } catch (_) { /* non-fatal */ }
 }
@@ -218,18 +245,18 @@ function renderEntries(ticketId, entries) {
     const input = document.createElement('input');
     input.type = 'text';
     input.value = parseFloat(entry.time_unit).toFixed(2);
-    input.title = 'Minutes - edit and press Save';
+    input.title = t('minutesTitle');
 
     const saveBtn = document.createElement('button');
-    saveBtn.textContent = 'Save';
+    saveBtn.textContent = t('save');
     saveBtn.className = 'save';
     saveBtn.onclick = async () => {
       const minutes = parseFloat(input.value);
-      if (isNaN(minutes) || minutes < 0) { setStatus('Invalid time value.', 'error'); return; }
+      if (isNaN(minutes) || minutes < 0) { setStatus(t('invalidTime'), 'error'); return; }
       saveBtn.disabled = true;
       try {
         await patchTimeAccounting(ticketId, entry.id, minutes);
-        setStatus('Entry updated.', 'ok');
+        setStatus(t('entryUpdated'), 'ok');
         refreshTicketData(ticketId);
       } catch (e) {
         setStatus(e.message, 'error');
@@ -240,7 +267,7 @@ function renderEntries(ticketId, entries) {
     const delBtn = document.createElement('button');
     delBtn.textContent = '-';
     delBtn.className = 'del';
-    delBtn.title = `Delete ${parseFloat(entry.time_unit).toFixed(2)} min entry`;
+    delBtn.title = t('deleteEntryTitle', parseFloat(entry.time_unit).toFixed(2));
     delBtn.onclick = () => {
       // Replace the row with an inline yes/no prompt.
       // Chrome's native confirm() freezes the extension popup and puts the
@@ -249,17 +276,17 @@ function renderEntries(ticketId, entries) {
 
       const msg = document.createElement('span');
       msg.className = 'entry-date';
-      msg.textContent = 'Delete this entry?';
+      msg.textContent = t('deleteThisEntry');
 
       const yesBtn = document.createElement('button');
-      yesBtn.textContent = 'Yes';
+      yesBtn.textContent = t('yes');
       yesBtn.className = 'save';
       yesBtn.onclick = async () => {
         yesBtn.disabled = true;
         noBtn.disabled = true;
         try {
           await deleteTimeAccounting(ticketId, entry.id);
-          setStatus('Entry deleted.', 'ok');
+          setStatus(t('entryDeleted'), 'ok');
         } catch (e) {
           setStatus(e.message, 'error');
         }
@@ -267,7 +294,7 @@ function renderEntries(ticketId, entries) {
       };
 
       const noBtn = document.createElement('button');
-      noBtn.textContent = 'No';
+      noBtn.textContent = t('no');
       noBtn.onclick = () => refreshTicketData(ticketId);
 
       row.append(msg, yesBtn, noBtn);
@@ -294,7 +321,7 @@ async function loadTicketById(id) {
     return;
   }
 
-  setStatus('Loading...');
+  setStatus(t('loading'));
   try {
     const [ticket, entries] = await Promise.all([
       zammadFetch(`/api/v1/tickets/${id}`),
@@ -328,11 +355,11 @@ $('loadNumBtn').onclick = async () => {
   const raw = $('ticketInput').value.trim();
   if (!raw) { await loadTicketById(''); return; }
 
-  setStatus('Resolving ticket number...');
+  setStatus(t('resolvingNum'));
   $('loadNumBtn').disabled = true;
   try {
     const resolvedId = await resolveTicketNumber(raw);
-    setStatus(`Resolved #${raw} → ID ${resolvedId}`);
+    setStatus(t('resolved', raw, resolvedId));
     await loadTicketById(resolvedId);
   } catch (e) {
     setStatus(e.message, 'error');
@@ -379,17 +406,17 @@ $('submitBtn').onclick = async () => {
   await store.set({ accumulatedMs: ms, startedAt: null });
   render();
 
-  if (ms < 1000) { setStatus('Nothing to submit - timer is at zero.', 'error'); return; }
+  if (ms < 1000) { setStatus(t('nothingToSubmit'), 'error'); return; }
 
-  setStatus('Submitting...');
+  setStatus(t('submitting'));
   try {
     const minutes = ms / 60000;
     // Build note: user text, optional "time | type" line, optional signature.
     const timePart = s.includeTime
-      ? `time submitted: ${parseFloat(minutes.toFixed(2))} min`
+      ? t('noteTimeSubmitted', parseFloat(minutes.toFixed(2)))
       : null;
     const typePart = s.activityTypeEnabled && s.activityTypeName
-      ? `activity type: ${s.activityTypeName}`
+      ? t('noteActivityType', s.activityTypeName)
       : null;
     const timeLine = [timePart, typePart].filter(Boolean).join(' | ') || null;
 
@@ -399,7 +426,7 @@ $('submitBtn').onclick = async () => {
       s.signature
     ].filter(Boolean);
 
-    const note = parts.join('\n') || 'Time logged via extension';
+    const note = parts.join('\n') || t('noteDefault');
     const effectiveTypeName = s.activityTypeEnabled && s.activityTypeName
       ? s.activityTypeName
       : null;
@@ -408,7 +435,7 @@ $('submitBtn').onclick = async () => {
     // Reset timer on success
     await store.set({ accumulatedMs: 0, startedAt: null, note: '' });
     $('note').value = '';
-    setStatus(`Submitted ${parseFloat(minutes.toFixed(2))} min.`, 'ok');
+    setStatus(t('submitted', parseFloat(minutes.toFixed(2))), 'ok');
 
     // Refresh the accounted total so user can see it updated
     refreshTicketData(s.ticketId);
@@ -423,9 +450,29 @@ $('submitBtn').onclick = async () => {
 // ---------------------------------------------------------------------------
 
 (async () => {
-  const s = await store.get(['ticketId', 'zammadUrl', 'zammadToken', 'darkMode', 'note']);
+  const s = await store.get([
+    'ticketId', 'zammadUrl', 'zammadToken', 'darkMode', 'note',
+    'startedAt', 'accumulatedMs', 'language'
+  ]);
+
+  setLang(s.language || 'en');
+  applyStaticI18n();
+
   if (s.darkMode) document.body.classList.add('dark');
   if (s.note) $('note').value = s.note;
+
+  // Auto-fill the ticket from the active tab's URL when it sits under the
+  // configured Base URL. We only adopt it when the popup has no unsubmitted
+  // time on another ticket, so a running/banked timer is never discarded.
+  const urlTicketId  = await detectTicketFromActiveTab(s.zammadUrl);
+  const hasUnsubmitted = !!s.startedAt || (s.accumulatedMs || 0) > 0;
+
+  if (urlTicketId && urlTicketId !== s.ticketId && !hasUnsubmitted
+      && s.zammadUrl && s.zammadToken) {
+    // loadTicketById fetches the ticket, resets the timer and re-renders.
+    await loadTicketById(urlTicketId);
+    return;
+  }
 
   if (s.ticketId && s.zammadUrl && s.zammadToken) {
     $('ticketInput').value = s.ticketId;

--- a/firefox/settings.html
+++ b/firefox/settings.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="utf-8">
   <style>
     body {
       font-family: Arial, sans-serif;
@@ -81,53 +82,60 @@
   </style>
 </head>
 <body>
-  <h2>Zammad Settings</h2>
+  <h2 data-i18n="settingsTitle">Zammad Settings</h2>
 
-  <label>Base URL <small>(no trailing slash)</small></label>
-  <input id="url" type="text" placeholder="https://support.example.com">
+  <label><span data-i18n="baseUrl">Base URL</span> <small data-i18n="baseUrlHint">(no trailing slash)</small></label>
+  <input id="url" type="text" data-i18n-placeholder="urlPlaceholder" placeholder="https://support.example.com">
 
-  <label>API Token</label>
-  <input id="token" type="password" placeholder="Your Zammad API token">
+  <label data-i18n="apiToken">API Token</label>
+  <input id="token" type="password" data-i18n-placeholder="tokenPlaceholder" placeholder="Your Zammad API token">
 
-  <label>Note Signature <small>(appended to every note)</small></label>
-  <input id="signature" type="text" placeholder="e.g. Logged via Zammad Browser Extension">
+  <label><span data-i18n="noteSignature">Note Signature</span> <small data-i18n="noteSignatureHint">(appended to every note)</small></label>
+  <input id="signature" type="text" data-i18n-placeholder="signaturePlaceholder" placeholder="e.g. Logged via Zammad Browser Extension">
 
   <label class="checkbox-label">
     <input id="includeTime" type="checkbox">
-    Include submitted time in note body
+    <span data-i18n="includeTime">Include submitted time in note body</span>
   </label>
 
   <hr>
 
+  <label data-i18n="languageLabel">Language</label>
+  <select id="language">
+    <option value="en">English</option>
+    <option value="de">Deutsch</option>
+  </select>
+
   <label class="checkbox-label">
     <input id="darkMode" type="checkbox">
-    Dark mode
+    <span data-i18n="darkMode">Dark mode</span>
   </label>
 
   <hr>
 
   <label class="checkbox-label">
     <input id="activityTypeEnabled" type="checkbox">
-    Enable Activity Type on submission
+    <span data-i18n="activityTypeEnable">Enable Activity Type on submission</span>
   </label>
 
   <div id="activityTypeSection">
     <div class="fetch-row">
       <select id="activityTypeSelect">
-        <option value="">-- click Fetch --</option>
+        <option value="" data-i18n="clickFetch">-- click Fetch --</option>
       </select>
-      <button id="fetchTypesBtn" type="button">Fetch Types</button>
+      <button id="fetchTypesBtn" type="button" data-i18n="fetchTypes">Fetch Types</button>
     </div>
     <div id="fetchStatus"></div>
-    <p class="hint">
+    <p class="hint" data-i18n-html="activityTypeHint">
       Types must be enabled and established. Find them at:<br>
       <strong>Admin &rarr; Time Accounting &rarr; Activity Types</strong>.
     </p>
   </div>
 
-  <button id="saveBtn">Save</button>
+  <button id="saveBtn" data-i18n="save">Save</button>
   <div id="msg"></div>
 
+  <script src="i18n.js"></script>
   <script src="settings.js"></script>
 </body>
 </html>

--- a/firefox/settings.js
+++ b/firefox/settings.js
@@ -13,8 +13,12 @@ function preselectType(name) {
 }
 
 chrome.storage.local.get(
-  ['zammadUrl', 'zammadToken', 'signature', 'includeTime', 'darkMode', 'activityTypeEnabled', 'activityTypeName'],
-  ({ zammadUrl, zammadToken, signature, includeTime, darkMode, activityTypeEnabled, activityTypeName }) => {
+  ['zammadUrl', 'zammadToken', 'signature', 'includeTime', 'darkMode', 'language', 'activityTypeEnabled', 'activityTypeName'],
+  ({ zammadUrl, zammadToken, signature, includeTime, darkMode, language, activityTypeEnabled, activityTypeName }) => {
+    setLang(language || 'en');
+    get('language').value = language || 'en';
+    applyStaticI18n();
+
     if (zammadUrl)  get('url').value       = zammadUrl;
     if (zammadToken) get('token').value    = zammadToken;
     if (signature)  get('signature').value = signature;
@@ -28,6 +32,12 @@ chrome.storage.local.get(
     if (activityTypeName)    preselectType(activityTypeName);
   }
 );
+
+// Re-translate the page live when the language changes (saved on Save).
+get('language').addEventListener('change', () => {
+  setLang(get('language').value);
+  applyStaticI18n();
+});
 
 get('darkMode').addEventListener('change', () => {
   document.body.classList.toggle('dark', get('darkMode').checked);
@@ -49,12 +59,12 @@ get('fetchTypesBtn').onclick = async () => {
 
   if (!url || !token) {
     status.style.color = 'red';
-    status.textContent = 'Save your URL and Token first.';
+    status.textContent = t('saveUrlTokenFirst');
     return;
   }
 
   status.style.color = '#888';
-  status.textContent = 'Fetching...';
+  status.textContent = t('fetching');
 
   const authHeaders = { 'Authorization': `Token token=${token}` };
 
@@ -96,26 +106,26 @@ get('fetchTypesBtn').onclick = async () => {
       types = [...new Set(log.map(e => e.type).filter(Boolean))].sort();
     } catch (e) {
       status.style.color = 'red';
-      status.textContent = `Failed: ${e.message}`;
+      status.textContent = t('fetchFailed', e.message);
       return;
     }
   }
 
   if (!types.length) {
     status.style.color = '#888';
-    status.textContent =
-      'No active activity types found. Create them at Admin → Time Accounting → Activity Types.';
+    status.textContent = t('noTypesFound');
     return;
   }
 
   const select  = get('activityTypeSelect');
   const current = select.value;
-  select.innerHTML = '<option value="">-- select a type --</option>';
+  select.innerHTML = '';
+  select.add(new Option(t('selectAType'), ''));
   types.forEach(name => select.add(new Option(name, name)));
   if (current) select.value = current;
 
   status.style.color = 'green';
-  status.textContent = `Loaded ${types.length} type${types.length === 1 ? '' : 's'}.`;
+  status.textContent = t('loadedTypes', types.length);
 };
 
 get('saveBtn').onclick = () => {
@@ -124,31 +134,32 @@ get('saveBtn').onclick = () => {
   const signature           = get('signature').value.trim();
   const includeTime         = get('includeTime').checked;
   const darkMode            = get('darkMode').checked;
+  const language            = get('language').value;
   const activityTypeEnabled = get('activityTypeEnabled').checked;
   const activityTypeName    = get('activityTypeSelect').value;
   const msg                 = get('msg');
 
   if (!url.startsWith('https://') && !url.startsWith('http://')) {
     msg.style.color = 'red';
-    msg.textContent = 'URL must start with http:// or https://';
+    msg.textContent = t('urlMustStart');
     return;
   }
   if (!token) {
     msg.style.color = 'red';
-    msg.textContent = 'API token is required.';
+    msg.textContent = t('tokenRequired');
     return;
   }
   if (activityTypeEnabled && !activityTypeName) {
     msg.style.color = 'red';
-    msg.textContent = 'Select an activity type or disable the feature.';
+    msg.textContent = t('selectTypeOrDisable');
     return;
   }
 
   chrome.storage.local.set(
-    { zammadUrl: url, zammadToken: token, signature, includeTime, darkMode, activityTypeEnabled, activityTypeName },
+    { zammadUrl: url, zammadToken: token, signature, includeTime, darkMode, language, activityTypeEnabled, activityTypeName },
     () => {
       msg.style.color = 'green';
-      msg.textContent = 'Saved.';
+      msg.textContent = t('saved');
     }
   );
 };


### PR DESCRIPTION
…b URL

- Add lightweight i18n (i18n.js) with English and German dictionaries, loaded by both popup and settings; language is selectable in Settings and stored in chrome.storage.local.
- Translate all popup/settings UI strings, status messages and the submitted note body via data-i18n* attributes and a t() helper.
- Auto-detect the ticket from the active tab URL (#ticket/zoom/<id>) when it matches the configured Base URL; only adopts it when no unsubmitted time exists, so a running timer is never discarded.
- Add <meta charset="utf-8"> to popup.html/settings.html so umlauts render correctly.